### PR TITLE
Fixed prototype pollution on object-traversed - set()

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,9 @@
       set: function (path, val) {
         //we will retrieve only up to the last path
         const traversedAlmost = traverseAlmost(obj, path);
+        if(obj.includes('__proto__') || obj.includes('constructor') || obj.includes('prototype')){
+          return false;
+        }
         if (traversedAlmost) {
           return traversedAlmost.traversed[traversedAlmost.childPath] = val;
         } else if (obj) {


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-traversed/

### ⚙️ Description *

`object-traversed` is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `obj` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `Yes! Its Polluted`.
```javascript
// poc.js
var objectTraversed = require("object-traversed")
var obj = {}
console.log("Before : " + {}.polluted);
objectTraversed(obj).set("__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.



### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `obj` and no breaking changes are introduced. :)
