### PR TITLE
Fix Prototype pollution by avoiding magic attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@
   }
   const traverse = function (obj, path) {
     return path.split(".").reduce(function (prev, current) {
-      if (prev) {
-        return prev[current];
-      }
+      if (!prev) return undefined;
+      if (prev[current] === Object.prototype) return prev;
+      return prev[current];
     }, obj);
   }
 
@@ -52,7 +52,7 @@
     }
     return undefined;
   };
-  const doNothing = () => {};
+  const doNothing = () => { };
 
   const noop = {
     get: doNothing, has: doNothing, set: doNothing, push: doNothing,

--- a/test/test.js
+++ b/test/test.js
@@ -85,7 +85,7 @@ describe('object traverse tests', function(){
         assert.equal(traverse(objMod).set('hey',1),1);
         assert.equal(traverse(objMod).get('hey'),1);
 
-        assert.equal(traverse(objMod).get('hey2',undefined));
+        assert.equal(traverse(objMod).get('hey2'), undefined);
         assert.equal(traverse(objMod).set('hey2','X'),'X');
         assert.equal(traverse(objMod).get('hey2'),'X');
 
@@ -96,6 +96,14 @@ describe('object traverse tests', function(){
         assert.equal(traverse(objMod).get('subField.newPath.x'),'x');
         assert.equal(traverse(objMod).get('subField.newPath.y'),'y');
     });
+
+
+    it('should not allow protopath overwrite', function() {
+      traverse({}).set('__proto__.polluted', true);
+      assert.equal({}.polluted, undefined);
+      traverse({}).set('constructor.prototype.polluted', true);
+      assert.equal({}.polluted, undefined);
+    })
 
     var objFunc = {
         field: function(a) {
@@ -127,10 +135,10 @@ describe('object traverse tests', function(){
         nested: { x : 'y'}
     };
     it ( 'should properly delete path' , function() {
-        assert.equal(traverse(deleteObj).delete('x'));
+        assert.equal(traverse(deleteObj).delete('x'), undefined);
         assert.equal(traverse(deleteObj).get('x'),undefined);
         assert.equal(traverse(deleteObj).get('nested.x'),'y');
-        assert.equal(traverse(deleteObj).delete('nested.x'));
+        assert.equal(traverse(deleteObj).delete('nested.x'), undefined);
         assert.equal(traverse(deleteObj).get('nested.x'),undefined);
     });
 


### PR DESCRIPTION
### 📊 Metadata *

`Prototype Pollution` in `object-traversed`

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-traversed/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var objectTraversed = require("object-traversed")
var obj = {}
console.log("Before : " + {}.polluted);
objectTraversed(obj).set("__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```

2. Execute the following commands in terminal:

```
npm i object-traversed # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/107751754-d218a900-6d43-11eb-833b-5618a8a11261.png)

After:
![image](https://user-images.githubusercontent.com/64132745/107751672-bd3c1580-6d43-11eb-84ff-85443568c9cd.png)

### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.
![image](https://user-images.githubusercontent.com/64132745/107752255-7d296280-6d44-11eb-9d48-83633666de18.png)

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1862
